### PR TITLE
Fix error endlessly appending to spellUpgrades table

### DIFF
--- a/general.lua
+++ b/general.lua
@@ -500,7 +500,7 @@ local spellUpgrades = {
 
 local function ScanUpgrades()
 	playerClass = playerClass or select(2, UnitClass('player'))
-	local upgrades = spellUpgrades[playerClass][5] or {}
+	local upgrades = CopyTable(spellUpgrades[playerClass][5] or {})
 	local spec = GetSpecialization()
 
 	if spec > 0 and spec < 5 then


### PR DESCRIPTION
Fixes an error where ScanUpdates fails to copy the class common spell table and instead endlessly appends to it.

Addresses https://github.com/AdiAddons/AdiButtonAuras/issues/388

Not the complete fix, because in Torghast SPELLS_CHANGED can fire 2 times per second making in not a good event for detecting actual changes to the spellbook. But it does make the problem not get linearly worse over time.